### PR TITLE
This disables the cache for the JwksFetcher class

### DIFF
--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -15,5 +15,7 @@ framework:
         #app: cache.adapter.apcu
 
         # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            # creates a cache.noop service that doesn't actually cache
+            cache.noop:
+                adapter: cache.adapter.array

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -2,14 +2,17 @@
 
 namespace App;
 
+use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcherInterface;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
-class Kernel extends BaseKernel
+class Kernel extends BaseKernel implements CompilerPassInterface
 {
     use MicroKernelTrait;
 
@@ -50,5 +53,14 @@ class Kernel extends BaseKernel
         $routes->import($confDir.'/{routes}/'.$this->environment.'/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
+    }
+
+    public function process(ContainerBuilder $container)
+    {
+        // this replaces the first argument of the JwksFetcherInterface service
+        // (which is really the class JwksFetcher) with a "fake cache" that
+        // doesn't actually cache. This is because
+        $jwksFetcherDefinition = $container->getDefinition(JwksFetcherInterface::class);
+        $jwksFetcherDefinition->replaceArgument(0, new Reference('cache.noop'));
     }
 }


### PR DESCRIPTION
A possible workaround for a bug where the jwks "keys" are expiring
more quickly than our cache. In fact, the JwksFetcher appears to cache
the keys for 24 hours, but in fact, the keys appear to have a lifetime
of about 1 hour.

Cheers!