### PR TITLE
Reverts the JwksFetcher if the fix is merged in the main library

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2585,16 +2585,16 @@
         },
         {
             "name": "oat-sa/lib-lti1p3-core",
-            "version": "3.1.1",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/oat-sa/lib-lti1p3-core.git",
-                "reference": "ff90dd2dad45d857fdc5ce69e3b8b5f0d853b957"
+                "reference": "5f2490aa9bd8146d834faa7159f3365a1bc65a4d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-core/zipball/ff90dd2dad45d857fdc5ce69e3b8b5f0d853b957",
-                "reference": "ff90dd2dad45d857fdc5ce69e3b8b5f0d853b957",
+                "url": "https://api.github.com/repos/oat-sa/lib-lti1p3-core/zipball/5f2490aa9bd8146d834faa7159f3365a1bc65a4d",
+                "reference": "5f2490aa9bd8146d834faa7159f3365a1bc65a4d",
                 "shasum": ""
             },
             "require": {
@@ -2629,7 +2629,11 @@
                 "GPL-2.0-only"
             ],
             "description": "OAT LTI 1.3 Core Library",
-            "time": "2020-10-22T06:06:33+00:00"
+            "support": {
+                "issues": "https://github.com/oat-sa/lib-lti1p3-core/issues",
+                "source": "https://github.com/oat-sa/lib-lti1p3-core/tree/3.2.1"
+            },
+            "time": "2020-11-20T17:51:49+00:00"
         },
         {
             "name": "oat-sa/lib-lti1p3-nrps",

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -15,7 +15,5 @@ framework:
         #app: cache.adapter.apcu
 
         # Namespaced pools use the above "app" backend by default
-        pools:
-            # creates a cache.noop service that doesn't actually cache
-            cache.noop:
-                adapter: cache.adapter.array
+        #pools:
+            #my.dedicated.cache: null

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -2,17 +2,14 @@
 
 namespace App;
 
-use OAT\Library\Lti1p3Core\Security\Jwks\Fetcher\JwksFetcherInterface;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 
-class Kernel extends BaseKernel implements CompilerPassInterface
+class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
@@ -53,14 +50,5 @@ class Kernel extends BaseKernel implements CompilerPassInterface
         $routes->import($confDir.'/{routes}/'.$this->environment.'/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}/*'.self::CONFIG_EXTS, '/', 'glob');
         $routes->import($confDir.'/{routes}'.self::CONFIG_EXTS, '/', 'glob');
-    }
-
-    public function process(ContainerBuilder $container)
-    {
-        // this replaces the first argument of the JwksFetcherInterface service
-        // (which is really the class JwksFetcher) with a "fake cache" that
-        // doesn't actually cache. This is because
-        $jwksFetcherDefinition = $container->getDefinition(JwksFetcherInterface::class);
-        $jwksFetcherDefinition->replaceArgument(0, new Reference('cache.noop'));
     }
 }


### PR DESCRIPTION
I created a fix to the upstream library for our caching problem - https://github.com/oat-sa/lib-lti1p3-core/pull/68

The maintainer was nice enough to merge it for us (🎆 ) and I've upgraded to the version that contains the fix. Our workaround is no longer needed.

This is ready to merge!

Cheers!